### PR TITLE
DPTXlator4ByteFloat getValues() uses different locales based on value (#5)

### DIFF
--- a/src/tuwien/auto/calimero/dptxlator/DPTXlator4ByteFloat.java
+++ b/src/tuwien/auto/calimero/dptxlator/DPTXlator4ByteFloat.java
@@ -777,9 +777,9 @@ public class DPTXlator4ByteFloat extends DPTXlator
 	private String makeString(final int index)
 	{
 		final float f = fromDPT(index);
-		String s="";
+		String s;
 		if (Math.abs(f) < 100000) {
-			String.valueOf(f);
+			s=String.valueOf(f);
 		}
 		else {
 			NumberFormat dcf = NumberFormat.getInstance(Locale.US);


### PR DESCRIPTION
DPTXlator4ByteFloat was using different locales within makeString() method. If the float is less then 100000 then String.valueOf() would be used, which is actually Float.toString(). This is a non-localized method. If the float is larger or equal 100000 then DecimalFormat("0.#####E0").format() would used. DecimalFormat uses the default locale. Otherwise, String.format() was used which is not localized.
Since DPTXlator2ByteFloat is also using non-localized output: I changed the output to non-localized (US).
