### PR TITLE
Feat/group unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,12 @@
 
 # OS X
 .DS_Store
+
+#Intellij
+calimero-core.iml
+.idea
+
+#Maven
+target
+test
+

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ calimero-core.iml
 
 #Maven
 target
-test
+test/commandDP.xml
+test/stateDP.xml
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,10 @@
 		</developer>
 	</developers>
 
+	<properties>
+		<test.exclude.groups>category.RequireKNXNetworkLink,category.RequireDiscover,category.RequireFT12Connection,category.RequirePerf</test.exclude.groups>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -62,9 +66,11 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.19</version>
 				<configuration>
 					<useFile>false</useFile>
+					<!--<groups>category.SimpleTest</groups>-->
+					<excludedGroups>${test.exclude.groups}</excludedGroups>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -92,4 +98,13 @@
 			<version>1.0-2</version>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>testAll</id>
+			<properties>
+				<test.exclude.groups></test.exclude.groups>
+			</properties>
+		</profile>
+	</profiles>
 </project>

--- a/src/tuwien/auto/calimero/knxnetip/KNXnetIPTunnel.java
+++ b/src/tuwien/auto/calimero/knxnetip/KNXnetIPTunnel.java
@@ -41,6 +41,7 @@ import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
+import java.util.Objects;
 
 import tuwien.auto.calimero.CloseEvent;
 import tuwien.auto.calimero.KNXException;
@@ -61,6 +62,9 @@ import tuwien.auto.calimero.knxnetip.servicetype.ServiceRequest;
 import tuwien.auto.calimero.knxnetip.util.TunnelCRI;
 import tuwien.auto.calimero.log.LogService.LogLevel;
 
+import static tuwien.auto.calimero.knxnetip.KNXnetIPTunnel.TUNNEL_LAYER.*;
+import static tuwien.auto.calimero.knxnetip.KNXnetIPTunnel.TUNNEL_LAYER.BUS_MONITOR_LAYER;
+
 /**
  * KNXnet/IP connection for KNX tunneling.
  * <p>
@@ -78,33 +82,55 @@ public class KNXnetIPTunnel extends ClientConnection
 	 */
 	public static final int TUNNEL_CONNECTION = 0x04;
 
-	/**
-	 * Tunneling on busmonitor layer, establishes a busmonitor tunnel to the KNX network.
-	 */
-	public static final int BUSMONITOR_LAYER = 0x80;
 
-	/**
-	 * Tunneling on link layer, establishes a link layer tunnel to the KNX network.
-	 */
-	public static final int LINK_LAYER = 0x02;
+	public enum TUNNEL_LAYER {
+		/**
+		 * Tunneling on busmonitor layer, establishes a busmonitor tunnel to the KNX network.
+		 */
+		BUS_MONITOR_LAYER(0x80),
+		/**
+		 * Tunneling on link layer, establishes a link layer tunnel to the KNX network.
+		 */
+		LINK_LAYER(0x02),
+		/**
+		 * Tunneling on raw layer, establishes a raw tunnel to the KNX network.
+		 */
+		RAW_LAYER(0x04);
 
-	/**
-	 * Tunneling on raw layer, establishes a raw tunnel to the KNX network.
-	 */
-	public static final int RAW_LAYER = 0x04;
+		private final byte code;
+
+		TUNNEL_LAYER(final int hexaCode) {
+			code = (byte) hexaCode;
+		}
+
+		public final byte getCode() {
+			return code;
+		}
+
+		public boolean isCodeValid() {
+			return ( code < 0 || code > 0xff) ? false : true;
+		}
+
+
+	}
+//	public static final int BUSMONITOR_LAYER = 0x80;
+//
+//	public static final int LINK_LAYER = 0x02;
+//
+//	public static final int RAW_LAYER = 0x04;
 
 	// client SHALL wait 1 second for acknowledgment response to a
 	// tunneling request from server
 	private static final int TUNNELING_REQ_TIMEOUT = 1;
 
-	private final int layer;
+	private final TUNNEL_LAYER layer;
 
 	/**
 	 * Creates a new KNXnet/IP tunneling connection to a remote server.
 	 * <p>
-	 * Establishing a raw tunneling layer ({@link #RAW_LAYER}) is not supported yet.<br>
+	 * Establishing a raw tunneling layer ({@link tuwien.auto.calimero.knxnetip.KNXnetIPTunnel.TUNNEL_LAYER#RAW_LAYER}) is not supported yet.<br>
 	 *
-	 * @param knxLayer KNX tunneling layer (e.g. {@link #LINK_LAYER})
+	 * @param knxLayer KNX tunneling layer (e.g. {@link TUNNEL_LAYER#LINK_LAYER})
 	 * @param localEP specifies the local endpoint with the socket address to be used by
 	 *        the tunnel
 	 * @param serverCtrlEP control endpoint of the server to establish connection to
@@ -118,15 +144,13 @@ public class KNXnetIPTunnel extends ClientConnection
 	 * @throws InterruptedException on interrupted thread while creating tunneling
 	 *         connection
 	 */
-	public KNXnetIPTunnel(final int knxLayer, final InetSocketAddress localEP,
+	public KNXnetIPTunnel(final TUNNEL_LAYER knxLayer, final InetSocketAddress localEP,
 		final InetSocketAddress serverCtrlEP, final boolean useNAT) throws KNXException,
 		InterruptedException
 	{
 		super(KNXnetIPHeader.TUNNELING_REQ, KNXnetIPHeader.TUNNELING_ACK, 2, TUNNELING_REQ_TIMEOUT);
-		if (knxLayer == RAW_LAYER)
-			throw new KNXIllegalArgumentException("raw tunnel to KNX network not supported");
-		if (knxLayer != LINK_LAYER && knxLayer != BUSMONITOR_LAYER)
-			throw new KNXIllegalArgumentException("unknown KNX layer");
+		if (Objects.isNull(knxLayer) || knxLayer == RAW_LAYER)
+			throw new KNXIllegalArgumentException("Raw tunnel to KNX network not supported: "+knxLayer);
 		layer = knxLayer;
 		connect(localEP, serverCtrlEP, new TunnelCRI(knxLayer), useNAT);
 	}
@@ -143,7 +167,7 @@ public class KNXnetIPTunnel extends ClientConnection
 	public void send(final CEMI frame, final BlockingMode mode) throws KNXTimeoutException,
 		KNXConnectionClosedException
 	{
-		if (layer == BUSMONITOR_LAYER)
+		if (layer == BUS_MONITOR_LAYER)
 			throw new KNXIllegalStateException("send not permitted in busmonitor mode");
 		if (!(frame instanceof CEMILData))
 			throw new KNXIllegalArgumentException("unsupported cEMI type");

--- a/src/tuwien/auto/calimero/knxnetip/util/TunnelCRI.java
+++ b/src/tuwien/auto/calimero/knxnetip/util/TunnelCRI.java
@@ -39,6 +39,9 @@ package tuwien.auto.calimero.knxnetip.util;
 import tuwien.auto.calimero.KNXFormatException;
 import tuwien.auto.calimero.KNXIllegalArgumentException;
 import tuwien.auto.calimero.knxnetip.KNXnetIPTunnel;
+import tuwien.auto.calimero.knxnetip.KNXnetIPTunnel.TUNNEL_LAYER;
+
+import static tuwien.auto.calimero.knxnetip.KNXnetIPTunnel.TUNNEL_CONNECTION;
 
 /**
  * Connection request information used for KNX tunneling connection.
@@ -61,7 +64,7 @@ public class TunnelCRI extends CRI
 	public TunnelCRI(final byte[] data, final int offset) throws KNXFormatException
 	{
 		super(data, offset);
-		if (getConnectionType() != KNXnetIPTunnel.TUNNEL_CONNECTION)
+		if (getConnectionType() != TUNNEL_CONNECTION)
 			throw new KNXFormatException("not a tunneling CRI", getConnectionType());
 		if (getStructLength() != 4)
 			throw new KNXFormatException("wrong length for tunneling CRI");
@@ -70,14 +73,12 @@ public class TunnelCRI extends CRI
 	/**
 	 * Creates a new CRI for tunnel connection type on the given KNX layer.
 	 * <p>
-	 * 
+	 *
 	 * @param knxLayer KNX layer specifying the kind of tunnel, e.g., link layer tunnel
 	 */
-	public TunnelCRI(final int knxLayer)
+	public TunnelCRI(final TUNNEL_LAYER knxLayer)
 	{
-		super(KNXnetIPTunnel.TUNNEL_CONNECTION, new byte[] { (byte) knxLayer, 0 });
-		if (knxLayer < 0 || knxLayer > 0xff)
-			throw new KNXIllegalArgumentException("KNX layer out of range [0..255]");
+		super(TUNNEL_CONNECTION, new byte[] { knxLayer.getCode(), 0 });
 	}
 
 	/**
@@ -91,7 +92,7 @@ public class TunnelCRI extends CRI
 	 */
 	TunnelCRI(final byte[] optionalData)
 	{
-		super(KNXnetIPTunnel.TUNNEL_CONNECTION, optionalData.clone());
+		super(TUNNEL_CONNECTION, optionalData.clone());
 		if (getStructLength() != 4)
 			throw new KNXIllegalArgumentException("wrong length for tunneling CRI");
 	}

--- a/src/tuwien/auto/calimero/link/KNXNetworkLinkIP.java
+++ b/src/tuwien/auto/calimero/link/KNXNetworkLinkIP.java
@@ -56,6 +56,8 @@ import tuwien.auto.calimero.knxnetip.KNXnetIPRouting;
 import tuwien.auto.calimero.knxnetip.KNXnetIPTunnel;
 import tuwien.auto.calimero.link.medium.KNXMediumSettings;
 
+import static tuwien.auto.calimero.knxnetip.KNXnetIPTunnel.TUNNEL_LAYER.LINK_LAYER;
+
 /**
  * Implementation of the KNX network link based on the KNXnet/IP protocol, using a
  * {@link KNXnetIPConnection}.
@@ -138,7 +140,7 @@ public class KNXNetworkLinkIP extends AbstractLink
 				catch (final UnknownHostException e) {
 					throw new KNXException("no local host available");
 				}
-			conn = new KNXnetIPTunnel(KNXnetIPTunnel.LINK_LAYER, local, remoteEP, useNAT);
+			conn = new KNXnetIPTunnel(LINK_LAYER, local, remoteEP, useNAT);
 			break;
 		case ROUTING:
 			NetworkInterface netIf = null;

--- a/src/tuwien/auto/calimero/link/KNXNetworkMonitorIP.java
+++ b/src/tuwien/auto/calimero/link/KNXNetworkMonitorIP.java
@@ -45,6 +45,8 @@ import tuwien.auto.calimero.knxnetip.KNXnetIPConnection;
 import tuwien.auto.calimero.knxnetip.KNXnetIPTunnel;
 import tuwien.auto.calimero.link.medium.KNXMediumSettings;
 
+import static tuwien.auto.calimero.knxnetip.KNXnetIPTunnel.TUNNEL_LAYER.BUS_MONITOR_LAYER;
+
 /**
  * Implementation of the KNX network monitor link based on the KNXnet/IP protocol, using a
  * {@link KNXnetIPConnection}. Once a monitor has been closed, it is not available for further link
@@ -75,7 +77,7 @@ public class KNXNetworkMonitorIP extends AbstractMonitor
 		final boolean useNAT, final KNXMediumSettings settings)
 			throws KNXException, InterruptedException
 	{
-		this(new KNXnetIPTunnel(KNXnetIPTunnel.BUSMONITOR_LAYER, localEndpoint(localEP), remoteEP,
+		this(new KNXnetIPTunnel(BUS_MONITOR_LAYER, localEndpoint(localEP), remoteEP,
 				useNAT), settings);
 		logger.info("in busmonitor mode - ready to receive");
 		((KNXnetIPTunnel) super.conn).addConnectionListener(notifier);

--- a/test/category/RequireDiscover.java
+++ b/test/category/RequireDiscover.java
@@ -1,0 +1,8 @@
+package category;
+
+/**
+ * Created by clalleme on 30/10/2015.
+ */
+public interface RequireDiscover {
+    /* category marker */
+}

--- a/test/category/RequireFT12Connection.java
+++ b/test/category/RequireFT12Connection.java
@@ -1,0 +1,8 @@
+package category;
+
+/**
+ * Created by clalleme on 30/10/2015.
+ */
+public interface RequireFT12Connection {
+    /* category marker */
+}

--- a/test/category/RequireKNXNetworkLink.java
+++ b/test/category/RequireKNXNetworkLink.java
@@ -1,0 +1,8 @@
+package category;
+
+/**
+ * Created by clalleme on 30/10/2015.
+ */
+public interface RequireKNXNetworkLink {
+    /* category marker */
+}

--- a/test/category/RequirePerf.java
+++ b/test/category/RequirePerf.java
@@ -1,0 +1,8 @@
+package category;
+
+/**
+ * Created by clalleme on 30/10/2015.
+ */
+public interface RequirePerf {
+    /* category marker */
+}

--- a/test/tuwien/auto/calimero/buffer/NetworkBufferTest.java
+++ b/test/tuwien/auto/calimero/buffer/NetworkBufferTest.java
@@ -38,7 +38,9 @@ package tuwien.auto.calimero.buffer;
 
 import java.util.Date;
 
+import category.RequireKNXNetworkLink;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.GroupAddress;
 import tuwien.auto.calimero.KNXException;
 import tuwien.auto.calimero.KNXIllegalStateException;
@@ -57,6 +59,7 @@ import tuwien.auto.calimero.process.ProcessCommunicatorImpl;
 /**
  * @author B. Malinowsky
  */
+@Category(RequireKNXNetworkLink.class)
 public class NetworkBufferTest extends TestCase
 {
 	private KNXNetworkLink lnk;

--- a/test/tuwien/auto/calimero/datapoint/DatapointMapTest.java
+++ b/test/tuwien/auto/calimero/datapoint/DatapointMapTest.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.List;
 
 import junit.framework.TestCase;
+import org.junit.Ignore;
 import tuwien.auto.calimero.GroupAddress;
 import tuwien.auto.calimero.Util;
 import tuwien.auto.calimero.xml.KNXMLException;
@@ -52,6 +53,7 @@ import tuwien.auto.calimero.xml.XmlWriter;
 /**
  * @author B. Malinowsky
  */
+@Ignore
 public class DatapointMapTest extends TestCase
 {
 	private static final String dpFile = Util.getTargetPath() + "datapointMap.xml";

--- a/test/tuwien/auto/calimero/dptxlator/DPTXlatorRGBTest.java
+++ b/test/tuwien/auto/calimero/dptxlator/DPTXlatorRGBTest.java
@@ -37,10 +37,12 @@
 package tuwien.auto.calimero.dptxlator;
 
 import junit.framework.TestCase;
+import org.junit.Ignore;
 
 /**
  * @author B. Malinowsky
  */
+@Ignore
 public class DPTXlatorRGBTest extends TestCase
 {
 	/**

--- a/test/tuwien/auto/calimero/knxnetip/DiscovererTest.java
+++ b/test/tuwien/auto/calimero/knxnetip/DiscovererTest.java
@@ -42,8 +42,10 @@ import java.net.SocketException;
 import java.util.Iterator;
 import java.util.List;
 
+import category.RequireDiscover;
 import junit.framework.AssertionFailedError;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.KNXException;
 import tuwien.auto.calimero.KNXIllegalArgumentException;
 import tuwien.auto.calimero.Util;
@@ -54,6 +56,7 @@ import tuwien.auto.calimero.knxnetip.servicetype.SearchResponse;
 /**
  * @author B. Malinowsky
  */
+@Category(RequireDiscover.class)
 public class DiscovererTest extends TestCase
 {
 	private Discoverer ddef;

--- a/test/tuwien/auto/calimero/knxnetip/KNXnetIPDevMgmtTest.java
+++ b/test/tuwien/auto/calimero/knxnetip/KNXnetIPDevMgmtTest.java
@@ -39,7 +39,9 @@ package tuwien.auto.calimero.knxnetip;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import category.RequireFT12Connection;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.CloseEvent;
 import tuwien.auto.calimero.FrameEvent;
 import tuwien.auto.calimero.IndividualAddress;
@@ -54,6 +56,7 @@ import tuwien.auto.calimero.knxnetip.KNXnetIPConnection.BlockingMode;
 /**
  * @author B. Malinowsky
  */
+@Category(RequireFT12Connection.class)
 public class KNXnetIPDevMgmtTest extends TestCase
 {
 //	private static KNXnetIPConnection.BlockingMode noblock =

--- a/test/tuwien/auto/calimero/knxnetip/KNXnetIPRouterTest.java
+++ b/test/tuwien/auto/calimero/knxnetip/KNXnetIPRouterTest.java
@@ -45,7 +45,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
 
+import category.RequireFT12Connection;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.CloseEvent;
 import tuwien.auto.calimero.FrameEvent;
 import tuwien.auto.calimero.GroupAddress;
@@ -60,6 +62,7 @@ import tuwien.auto.calimero.cemi.CEMILData;
 /**
  * @author B. Malinowsky
  */
+@Category(RequireFT12Connection.class)
 public class KNXnetIPRouterTest extends TestCase
 {
 	private static KNXnetIPConnection.BlockingMode noblock =

--- a/test/tuwien/auto/calimero/knxnetip/KNXnetIPTunnelTest.java
+++ b/test/tuwien/auto/calimero/knxnetip/KNXnetIPTunnelTest.java
@@ -56,6 +56,9 @@ import tuwien.auto.calimero.cemi.CEMI;
 import tuwien.auto.calimero.cemi.CEMIBusMon;
 import tuwien.auto.calimero.cemi.CEMILData;
 
+import static tuwien.auto.calimero.knxnetip.KNXnetIPTunnel.TUNNEL_LAYER.BUS_MONITOR_LAYER;
+import static tuwien.auto.calimero.knxnetip.KNXnetIPTunnel.TUNNEL_LAYER.LINK_LAYER;
+
 /**
  * @author B. Malinowsky
  */
@@ -394,13 +397,13 @@ public class KNXnetIPTunnelTest extends TestCase
 	 */
 	public final void testKNXnetIPTunnel() throws KNXException, InterruptedException
 	{
-		try (final KNXnetIPConnection c = new KNXnetIPTunnel(KNXnetIPTunnel.LINK_LAYER, null,
+		try (final KNXnetIPConnection c = new KNXnetIPTunnel(LINK_LAYER, null,
 				new InetSocketAddress("127.0.0.1", 4000), false)) {
 			fail("local socket is null");
 		}
 		catch (final KNXIllegalArgumentException e) {}
 
-		try (final KNXnetIPConnection c = new KNXnetIPTunnel(KNXnetIPTunnel.LINK_LAYER,
+		try (final KNXnetIPConnection c = new KNXnetIPTunnel(LINK_LAYER,
 				new InetSocketAddress("0.0.0.0", 0), new InetSocketAddress("127.0.0.1", 4000),
 				false)) {
 			fail("wildcard for local socket not null");
@@ -505,21 +508,21 @@ public class KNXnetIPTunnelTest extends TestCase
 
 	private void newTunnel() throws KNXException, InterruptedException
 	{
-		t = new KNXnetIPTunnel(KNXnetIPTunnel.LINK_LAYER, Util.getLocalHost(), Util.getServer(),
+		t = new KNXnetIPTunnel(LINK_LAYER, Util.getLocalHost(), Util.getServer(),
 				false);
 		t.addConnectionListener(l);
 	}
 
 	private void newNATTunnel() throws KNXException, InterruptedException
 	{
-		tnat = new KNXnetIPTunnel(KNXnetIPTunnel.LINK_LAYER, Util.getLocalHost(), Util.getServer(),
+		tnat = new KNXnetIPTunnel(LINK_LAYER, Util.getLocalHost(), Util.getServer(),
 				true);
 		tnat.addConnectionListener(lnat);
 	}
 
 	private void newMonitor() throws KNXException, InterruptedException
 	{
-		mon = new KNXnetIPTunnel(KNXnetIPTunnel.BUSMONITOR_LAYER, Util.getLocalHost(),
+		mon = new KNXnetIPTunnel(BUS_MONITOR_LAYER, Util.getLocalHost(),
 				Util.getServer(), false);
 		mon.addConnectionListener(lmon);
 	}

--- a/test/tuwien/auto/calimero/knxnetip/KNXnetIPTunnelTest.java
+++ b/test/tuwien/auto/calimero/knxnetip/KNXnetIPTunnelTest.java
@@ -40,7 +40,9 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Vector;
 
+import category.RequireFT12Connection;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.CloseEvent;
 import tuwien.auto.calimero.FrameEvent;
 import tuwien.auto.calimero.GroupAddress;
@@ -62,6 +64,7 @@ import static tuwien.auto.calimero.knxnetip.KNXnetIPTunnel.TUNNEL_LAYER.LINK_LAY
 /**
  * @author B. Malinowsky
  */
+@Category(RequireFT12Connection.class)
 public class KNXnetIPTunnelTest extends TestCase
 {
 	private static KNXnetIPConnection.BlockingMode noblock =

--- a/test/tuwien/auto/calimero/link/KNXNetworkLinkFT12Test.java
+++ b/test/tuwien/auto/calimero/link/KNXNetworkLinkFT12Test.java
@@ -36,7 +36,9 @@
 
 package tuwien.auto.calimero.link;
 
+import category.RequireFT12Connection;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.CloseEvent;
 import tuwien.auto.calimero.FrameEvent;
 import tuwien.auto.calimero.GroupAddress;
@@ -57,6 +59,7 @@ import tuwien.auto.calimero.link.medium.TPSettings;
  *
  * @author B. Malinowsky
  */
+@Category(RequireFT12Connection.class)
 public class KNXNetworkLinkFT12Test extends TestCase
 {
 	private KNXNetworkLink lnk;

--- a/test/tuwien/auto/calimero/link/KNXNetworkLinkIPTest.java
+++ b/test/tuwien/auto/calimero/link/KNXNetworkLinkIPTest.java
@@ -40,7 +40,9 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
+import category.RequireFT12Connection;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.CloseEvent;
 import tuwien.auto.calimero.FrameEvent;
 import tuwien.auto.calimero.GroupAddress;
@@ -60,6 +62,7 @@ import tuwien.auto.calimero.link.medium.TPSettings;
 /**
  * @author B. Malinowsky
  */
+@Category(RequireFT12Connection.class)
 public class KNXNetworkLinkIPTest extends TestCase
 {
 	private KNXNetworkLink tnl;

--- a/test/tuwien/auto/calimero/link/KNXNetworkMonitorFT12Test.java
+++ b/test/tuwien/auto/calimero/link/KNXNetworkMonitorFT12Test.java
@@ -36,7 +36,9 @@
 
 package tuwien.auto.calimero.link;
 
+import category.RequireFT12Connection;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.CloseEvent;
 import tuwien.auto.calimero.FrameEvent;
 import tuwien.auto.calimero.IndividualAddress;
@@ -55,6 +57,7 @@ import tuwien.auto.calimero.link.medium.TPSettings;
  *
  * @author B. Malinowsky
  */
+@Category(RequireFT12Connection.class)
 public class KNXNetworkMonitorFT12Test extends TestCase
 {
 	private KNXNetworkMonitor mon;

--- a/test/tuwien/auto/calimero/link/KNXNetworkMonitorIPTest.java
+++ b/test/tuwien/auto/calimero/link/KNXNetworkMonitorIPTest.java
@@ -38,7 +38,9 @@ package tuwien.auto.calimero.link;
 
 import java.net.InetSocketAddress;
 
+import category.RequireFT12Connection;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.CloseEvent;
 import tuwien.auto.calimero.FrameEvent;
 import tuwien.auto.calimero.IndividualAddress;
@@ -54,6 +56,7 @@ import tuwien.auto.calimero.link.medium.TPSettings;
 /**
  * @author B. Malinowsky
  */
+@Category(RequireFT12Connection.class)
 public class KNXNetworkMonitorIPTest extends TestCase
 {
 	private KNXNetworkMonitor mon;

--- a/test/tuwien/auto/calimero/mgmt/DestinationTest.java
+++ b/test/tuwien/auto/calimero/mgmt/DestinationTest.java
@@ -36,7 +36,9 @@
 
 package tuwien.auto.calimero.mgmt;
 
+import category.RequireKNXNetworkLink;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.CloseEvent;
 import tuwien.auto.calimero.DetachEvent;
 import tuwien.auto.calimero.FrameEvent;
@@ -53,6 +55,7 @@ import tuwien.auto.calimero.link.medium.TPSettings;
 /**
  * @author B. Malinowsky
  */
+@Category(RequireKNXNetworkLink.class)
 public class DestinationTest extends TestCase
 {
 	private KNXNetworkLink lnk;

--- a/test/tuwien/auto/calimero/mgmt/ManagementClientImplTest.java
+++ b/test/tuwien/auto/calimero/mgmt/ManagementClientImplTest.java
@@ -39,7 +39,9 @@ package tuwien.auto.calimero.mgmt;
 import java.util.Arrays;
 import java.util.List;
 
+import category.RequireKNXNetworkLink;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.IndividualAddress;
 import tuwien.auto.calimero.KNXException;
 import tuwien.auto.calimero.KNXFormatException;
@@ -56,6 +58,7 @@ import tuwien.auto.calimero.link.medium.TPSettings;
 /**
  * @author B. Malinowsky
  */
+@Category(RequireKNXNetworkLink.class)
 public class ManagementClientImplTest extends TestCase
 {
 	private KNXNetworkLink lnk;

--- a/test/tuwien/auto/calimero/mgmt/ManagementProceduresImplTest.java
+++ b/test/tuwien/auto/calimero/mgmt/ManagementProceduresImplTest.java
@@ -36,7 +36,9 @@
 
 package tuwien.auto.calimero.mgmt;
 
+import category.RequireKNXNetworkLink;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.IndividualAddress;
 import tuwien.auto.calimero.KNXException;
 import tuwien.auto.calimero.KNXTimeoutException;
@@ -49,6 +51,7 @@ import tuwien.auto.calimero.link.medium.TPSettings;
 /**
  * @author B. Malinowsky
  */
+@Category(RequireKNXNetworkLink.class)
 public class ManagementProceduresImplTest extends TestCase
 {
 	private ManagementProcedures mp;

--- a/test/tuwien/auto/calimero/mgmt/PropertyClientTest.java
+++ b/test/tuwien/auto/calimero/mgmt/PropertyClientTest.java
@@ -38,7 +38,9 @@ package tuwien.auto.calimero.mgmt;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import category.RequireKNXNetworkLink;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.CloseEvent;
 import tuwien.auto.calimero.IndividualAddress;
 import tuwien.auto.calimero.KNXException;
@@ -54,6 +56,7 @@ import tuwien.auto.calimero.mgmt.PropertyAccess.PID;
 /**
  * @author B. Malinowsky
  */
+@Category(RequireKNXNetworkLink.class)
 public class PropertyClientTest extends TestCase
 {
 	private static final String PIDResource = Util.getPath() + "properties.xml";

--- a/test/tuwien/auto/calimero/mgmt/TransportLayerImplTest.java
+++ b/test/tuwien/auto/calimero/mgmt/TransportLayerImplTest.java
@@ -39,7 +39,9 @@ package tuwien.auto.calimero.mgmt;
 import java.util.List;
 import java.util.Vector;
 
+import category.RequireKNXNetworkLink;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.CloseEvent;
 import tuwien.auto.calimero.DetachEvent;
 import tuwien.auto.calimero.FrameEvent;
@@ -61,6 +63,7 @@ import tuwien.auto.calimero.link.medium.TPSettings;
 /**
  * @author B. Malinowsky
  */
+@Category(RequireKNXNetworkLink.class)
 public class TransportLayerImplTest extends TestCase
 {
 	private KNXNetworkLink nl;

--- a/test/tuwien/auto/calimero/process/ProcessCommunicatorTest.java
+++ b/test/tuwien/auto/calimero/process/ProcessCommunicatorTest.java
@@ -36,7 +36,9 @@
 
 package tuwien.auto.calimero.process;
 
+import category.RequireKNXNetworkLink;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.DetachEvent;
 import tuwien.auto.calimero.GroupAddress;
 import tuwien.auto.calimero.KNXException;
@@ -55,6 +57,7 @@ import tuwien.auto.calimero.link.medium.TPSettings;
 /**
  * @author B. Malinowsky
  */
+@Category(RequireKNXNetworkLink.class)
 public class ProcessCommunicatorTest extends TestCase
 {
 	private ProcessCommunicator pc;

--- a/test/tuwien/auto/calimero/serial/FT12ConnectionTest.java
+++ b/test/tuwien/auto/calimero/serial/FT12ConnectionTest.java
@@ -38,7 +38,9 @@ package tuwien.auto.calimero.serial;
 
 import java.util.Arrays;
 
+import category.RequireFT12Connection;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 import tuwien.auto.calimero.KNXException;
 import tuwien.auto.calimero.Util;
 
@@ -47,6 +49,7 @@ import tuwien.auto.calimero.Util;
  * 
  * @author B. Malinowsky
  */
+@Category(RequireFT12Connection.class)
 public class FT12ConnectionTest extends TestCase
 {
 	private static int usePort = Util.getSerialPort();


### PR DESCRIPTION
I upgrade surefire in order to support exludedGroups.

I define a couple of annotations that are excluded by default (when no profile is activated)
Name is maybe not appropriate but could be rename easily. 

To run all tests:
> mvn -PtestAll test 

I mark 2 Test class with @Ignore:
* DPTXlatorRGBTest.java (Not Yet Implemented)
* DatapointMapTest.java (testLoad fail)