### PR TITLE
win7_OrLater field issue on Discoverer class

### DIFF
--- a/src/tuwien/auto/calimero/knxnetip/Discoverer.java
+++ b/src/tuwien/auto/calimero/knxnetip/Discoverer.java
@@ -141,7 +141,7 @@ public class Discoverer
 		if (os.indexOf("windows") >= 0) {
 			// minor: 0 = vista, 1 = win 7, 2 = win 8, 3 = win 8.1, 4 = win 10,  ...
 			final String ver = System.getProperty("os.version", "generic");
-			win7_OrLater = Double.parseDouble(ver) > 6.1;
+			win7_OrLater = Double.parseDouble(ver) >= 6.1;
 		}
 		if (os.indexOf("mac os x") >= 0)
 			osx = true;


### PR DESCRIPTION
I Think "win7_OrLater" should assign on this way
win7_OrLater = Double.parseDouble(ver) >= 6.1
Because the win7 kernel version is 6.1 .