### PR TITLE
added support for "High" priority

### DIFF
--- a/src/tuwien/auto/calimero/Priority.java
+++ b/src/tuwien/auto/calimero/Priority.java
@@ -117,6 +117,8 @@ public final class Priority
 	{
 		if ("system".equalsIgnoreCase(value))
 			return SYSTEM;
+		if ("high".equalsIgnoreCase(value))
+			return SYSTEM;
 		if ("normal".equalsIgnoreCase(value))
 			return NORMAL;
 		if ("urgent".equalsIgnoreCase(value))


### PR DESCRIPTION
for example a project generated with ETS 5.6 may contain datapoint types with priority="High".
I found this document(http://www.sti.uniurb.it/romanell/Domotica_e_Edifici_Intelligenti/110504-Lez10a-KNX-Datapoint%20Types%20v1.5.00%20AS.pdf), which assigns "0" to High priority, so using the existing type SYSTEM seems appropriate.