### PR TITLE
Fix invalid minimum buffer size and properly set status bits.

### DIFF
--- a/src/tuwien/auto/calimero/knxnetip/util/TunnelingDib.java
+++ b/src/tuwien/auto/calimero/knxnetip/util/TunnelingDib.java
@@ -79,7 +79,7 @@ public class TunnelingDib extends DIB {
 
 		if (type != Tunneling)
 			throw new KNXFormatException("not a tunneling DIB", type);
-		if (length < 4)
+		if (length < 8)
 			throw new KNXFormatException("tunneling DIB too short", length);
 
 		final ByteBuffer buf = ByteBuffer.wrap(data, offset + 2, length - 2);
@@ -120,8 +120,8 @@ public class TunnelingDib extends DIB {
 		buf.putShort(maxApduLength);
 		for (int k = 0; k < addresses.length; k++) {
 			buf.put(addresses[k].toByteArray());
-			buf.put((byte) 0); // reserved
-			buf.put((byte) status[k]);
+			buf.put((byte) 0xff); // reserved
+			buf.put((byte) (status[k] | 0xf8));
 		}
 		return buf.array();
 	}

--- a/test/tuwien/auto/calimero/knxnetip/servicetype/SearchResponseTest.java
+++ b/test/tuwien/auto/calimero/knxnetip/servicetype/SearchResponseTest.java
@@ -36,6 +36,8 @@
 
 package tuwien.auto.calimero.knxnetip.servicetype;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -131,5 +133,22 @@ class SearchResponseTest {
 
 		assertThrows(KNXIllegalArgumentException.class, () -> new SearchResponse(false, hpai, List.of(device)), "DIB list size < 2");
 		assertThrows(KNXIllegalArgumentException.class, () -> new SearchResponse(true, hpai, List.of(device)), "DIB list size < 2");
+	}
+
+	@Test
+	void testTunnelingDib() throws KNXFormatException {
+		assertThrows(KNXFormatException.class, () -> new TunnelingDib(tunneling.toByteArray(), 0, 4), "Dib size < 8");
+		assertThrows(KNXFormatException.class, () -> new TunnelingDib(tunneling.toByteArray(), 0, 5), "Dib size < 8");
+		assertThrows(KNXFormatException.class, () -> new TunnelingDib(tunneling.toByteArray(), 0, 6), "Dib size < 8");
+		assertThrows(KNXFormatException.class, () -> new TunnelingDib(tunneling.toByteArray(), 0, 7), "Dib size < 8");
+		assertDoesNotThrow(() -> new TunnelingDib(tunneling.toByteArray(), 0, 8));
+
+		TunnelingDib dib = tunneling;
+		byte[] bytes = new byte[]{(byte) 0x08, (byte) 0x07, (byte) 0x00, (byte) 0xfe, (byte) 0x12, (byte) 0x03, (byte) 0xff, (byte) 0xf9};
+		assertArrayEquals(bytes, dib.toByteArray());
+
+		dib = new TunnelingDib(List.of(new IndividualAddress(1, 2, 3)), new int[] { 7 });
+		bytes = new byte[]{(byte) 0x08, (byte) 0x07, (byte) 0x00, (byte) 0xfe, (byte) 0x12, (byte) 0x03, (byte) 0xff, (byte) 0xff};
+		assertArrayEquals(bytes, dib.toByteArray());
 	}
 }


### PR DESCRIPTION
The minimum size of a tunneling DIB consists out of 8 bytes, header
(2 Byte), max. ADPU length (2 Byte) and at least one tunneling slot
info object (4 Byte).

The status bits 15 to Bit 3 are reserved, though they need to be set
to 1 (KNX AN185 Page 23, Note 10).

Add additional test function to take that both conditions into account.