### PR TITLE
ProcessCommunicatorImpl: goDiagnostics to use correct SAL

### DIFF
--- a/src/tuwien/auto/calimero/mgmt/SecureManagement.java
+++ b/src/tuwien/auto/calimero/mgmt/SecureManagement.java
@@ -143,7 +143,7 @@ public class SecureManagement extends SecureApplicationLayer {
 	}
 
 	@Override
-	protected Security security() { return super.security(); };
+	public Security security() { return super.security(); };
 
 	protected TransportLayer transportLayer() { return transportLayer; }
 }

--- a/src/tuwien/auto/calimero/process/ProcessCommunicatorImpl.java
+++ b/src/tuwien/auto/calimero/process/ProcessCommunicatorImpl.java
@@ -442,7 +442,7 @@ public class ProcessCommunicatorImpl implements ProcessCommunicator
 
 	private void send(final GroupAddress dst, final Priority p, final int service, final DPTXlator t)
 			throws KNXTimeoutException, KNXLinkClosedException, InterruptedException {
-		final boolean useGoDiagnostics = Security.defaultInstallation().groupKeys().containsKey(dst);
+		final boolean useGoDiagnostics = sal.security().groupKeys().containsKey(dst);
 		if (useGoDiagnostics) {
 			try {
 				final var future = sal.writeGroupObjectDiagnostics(dst, t == null ? new byte[0] : t.getData());

--- a/src/tuwien/auto/calimero/secure/SecureApplicationLayer.java
+++ b/src/tuwien/auto/calimero/secure/SecureApplicationLayer.java
@@ -740,7 +740,7 @@ public class SecureApplicationLayer implements AutoCloseable {
 		link.removeLinkListener(linkListener);
 	}
 
-	protected Security security() { return security; }
+	public Security security() { return security; }
 
 	protected void dispatchLinkEvent(final FrameEvent e) {
 		final var cemi = e.getFrame();


### PR DESCRIPTION
Removed usage of Security.defaultInstallation() and use specific SAL
to decide if goDiagnostics is used. SecureApplication::security()
changed to package public.

Signed-off-by: Holger Friedrich <mail@holger-friedrich.de>