### PR TITLE
Cleanup documentation and modifiers

### DIFF
--- a/src/io/calimero/dptxlator/DPTXlatorDateTime.java
+++ b/src/io/calimero/dptxlator/DPTXlatorDateTime.java
@@ -982,7 +982,7 @@ public class DPTXlatorDateTime extends DPTXlator
 						int dow = DAYS.length - 1;
 						while (dow >= 0 && !DAYS[dow].toLowerCase().startsWith(prefix))
 							--dow;
-						final boolean anyday = dow == 0 && t.hasMoreTokens() && t.nextToken().equalsIgnoreCase("day");
+						final boolean anyday = dow == 0 && t.hasMoreTokens() && "day".equalsIgnoreCase(t.nextToken());
 						if (dow <= 0 && !anyday)
 							throw newException("wrong weekday", s, null);
 						set(dst, index, DOW, dow);

--- a/test/io/calimero/Util.java
+++ b/test/io/calimero/Util.java
@@ -239,7 +239,7 @@ public final class Util
 	 *
 	 * @return socket address
 	 */
-	public synchronized static InetSocketAddress getServer()
+	public static synchronized InetSocketAddress getServer()
 	{
 		// we try once to find our running test server, on failure subsequent calls will
 		// immediately return to speed up tests


### PR DESCRIPTION
- ~~Cleanup Javadoc annotations (removing brackets from {@return statements})~~
- Change modifiers according to JLS (~~mainly removing final from static methods, as static methods are implicitly final, but also~~ order of modifiers)
- Minor other improvements