### PR TITLE
Discoverer: Fix NPE when NetIf is not specified

### DIFF
--- a/src/io/calimero/knxnetip/Discoverer.java
+++ b/src/io/calimero/knxnetip/Discoverer.java
@@ -65,6 +65,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -215,7 +216,7 @@ public class Discoverer
 
 		@Override
 		public String toString() {
-			return hostPort(local) + " (" + ni.getName() + ") <- " + response;
+			return hostPort(local) + (ni == null ? "" : " (" + ni.getName() + ")") + " <- " + response;
 		}
 
 		@Override
@@ -225,9 +226,10 @@ public class Discoverer
 				return true;
 			if (!(obj instanceof final Result<?> other))
 				return false;
-			return getNetworkInterface().equals(other.getNetworkInterface())
-					&& localEndpoint().equals(other.localEndpoint())
-					&& getResponse().equals(other.getResponse()) && remote.equals(other.remote);
+			return Objects.equals(getNetworkInterface(), other.getNetworkInterface())
+					&&  Objects.equals(localEndpoint(), other.localEndpoint())
+					&& Objects.equals(getResponse(), other.getResponse())
+					&& Objects.equals(remote, other.remote);
 		}
 
 		@Override


### PR DESCRIPTION
The following code should work - if I read the javadoc correctly:

```
Discoverer discovererUdp = new Discoverer(0, false);
discovererUdp.startSearch(null, 5, true);
List<Result<SearchResponse>> responses = discovererUdp.getSearchResponses();
logger.warn("discovery {}", responses.toString());
```

However, ```toString()``` fails with 

> java.lang.NullPointerException: Cannot invoke "java.net.NetworkInterface.getName()" because "this.ni" is null

and during detection I see

> java.lang.NullPointerException: Cannot invoke "java.net.NetworkInterface.equals(Object)" because the return value of "tuwien.auto.calimero.knxnetip.Discoverer$Result.getNetworkInterface()" is null
        at tuwien.auto.calimero.knxnetip.Discoverer$Result.equals(Discoverer.java:225) ~[bundleFile:?]
        at java.util.ArrayList.indexOfRange(ArrayList.java:299) ~[?:?]
        at java.util.ArrayList.indexOf(ArrayList.java:286) ~[?:?]
        at java.util.ArrayList.contains(ArrayList.java:275) ~[?:?]
        at java.util.Collections$SynchronizedCollection.contains(Collections.java:2087) ~[?:?]
        at tuwien.auto.calimero.knxnetip.Discoverer$ReceiverLoop.onReceive(Discoverer.java:868) [bundleFile:?]
        at tuwien.auto.calimero.knxnetip.Discoverer$ReceiverLoop.receive(Discoverer.java:922) [bundleFile:?]
        at tuwien.auto.calimero.internal.UdpSocketLooper.loop(UdpSocketLooper.java:134) [bundleFile:?]
        at tuwien.auto.calimero.knxnetip.Discoverer$ReceiverLoop.run(Discoverer.java:840) [bundleFile:?]

Both is fixed by more restrictive null checks.

Or did I get the usage instructions wrong and a network interface should be supplied?
