### PR TITLE
Fix InterruptedException log

### DIFF
--- a/src/io/calimero/link/KNXNetworkLinkFT12.java
+++ b/src/io/calimero/link/KNXNetworkLinkFT12.java
@@ -41,7 +41,6 @@ import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 
-import java.lang.System.Logger.Level;
 import java.util.HexFormat;
 
 import io.calimero.FrameEvent;

--- a/src/io/calimero/link/KNXNetworkLinkFT12.java
+++ b/src/io/calimero/link/KNXNetworkLinkFT12.java
@@ -41,6 +41,7 @@ import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 
+import java.lang.System.Logger.Level;
 import java.util.HexFormat;
 
 import io.calimero.FrameEvent;
@@ -133,11 +134,14 @@ public class KNXNetworkLinkFT12 extends AbstractLink<FT12Connection>
 			conn.send(msg, waitForCon);
 			logger.log(TRACE, "send to {0} succeeded", dst);
 		}
-		catch (KNXPortClosedException | InterruptedException e) {
-			logger.log(ERROR, "send error, closing link", e);
+        catch (KNXPortClosedException | InterruptedException e) {
 			close();
-			if (e instanceof InterruptedException)
-				Thread.currentThread().interrupt();
+            if (e instanceof InterruptedException) {
+                logger.log(DEBUG, "InterruptedException send error, closing link");
+                Thread.currentThread().interrupt();
+            } else {
+                logger.log(ERROR, "send error, closing link", e);
+            }
 			throw new KNXLinkClosedException("link closed, " + e.getMessage());
 		}
 	}

--- a/src/io/calimero/link/KNXNetworkLinkFT12.java
+++ b/src/io/calimero/link/KNXNetworkLinkFT12.java
@@ -133,14 +133,14 @@ public class KNXNetworkLinkFT12 extends AbstractLink<FT12Connection>
 			conn.send(msg, waitForCon);
 			logger.log(TRACE, "send to {0} succeeded", dst);
 		}
-        catch (KNXPortClosedException | InterruptedException e) {
+		catch (KNXPortClosedException | InterruptedException e) {
 			close();
-            if (e instanceof InterruptedException) {
-                logger.log(DEBUG, "InterruptedException send error, closing link");
-                Thread.currentThread().interrupt();
-            } else {
-                logger.log(ERROR, "send error, closing link", e);
-            }
+			if (e instanceof InterruptedException) {
+			    logger.log(DEBUG, "InterruptedException send error, closing link");
+			    Thread.currentThread().interrupt();
+			} else {
+			    logger.log(ERROR, "send error, closing link", e);
+			}
 			throw new KNXLinkClosedException("link closed, " + e.getMessage());
 		}
 	}


### PR DESCRIPTION
An `InterruptException` should not log full stacktrace to ERROR level.

Fixes: https://github.com/openhab/openhab-addons/issues/8277