### PR TITLE
Skip explicit read back for state control properties (#150)

### DIFF
--- a/src/io/calimero/mgmt/ManagementClient.java
+++ b/src/io/calimero/mgmt/ManagementClient.java
@@ -566,7 +566,9 @@ public interface ManagementClient extends AutoCloseable
 	 * <p>
 	 * This service uses point-to-point connectionless or connection-oriented
 	 * communication mode.<br>
-	 * The value of the written property is explicitly read back after writing.<br>
+	 * The value of the written property is explicitly read back after writing.
+	 * Reading back the property value shall be skipped for properties returning a resulting
+	 * state code which may differ from the written value (e.g., properties of type {@code PDT_CONTROL}).<br>
 	 * Note that interface objects with active access protection are only accessible over
 	 * connection-oriented communication.
 	 *

--- a/src/io/calimero/mgmt/ManagementClientImpl.java
+++ b/src/io/calimero/mgmt/ManagementClientImpl.java
@@ -159,9 +159,6 @@ public class ManagementClientImpl implements ManagementClient
 
 	private static final int DomainAddressSerialNumberWrite = 0b1111101110;
 
-	private static final int PID_LOAD_STATE_CONTROL = 5;
-	private static final int PID_RUN_STATE_CONTROL = 6;
-
 	// serves as both req and res
 	private static final int RESTART = 0x0380;
 
@@ -793,7 +790,7 @@ public class ManagementClientImpl implements ManagementClient
 
 		// explicitly read back written properties
 		// skip if writing to load/run state control properties
-		if (propertyId != PID_LOAD_STATE_CONTROL && propertyId != PID_RUN_STATE_CONTROL) {
+		if (propertyId != PropertyAccess.PID.LOAD_STATE_CONTROL && propertyId != PropertyAccess.PID.RUN_STATE_CONTROL) {
 			for (int i = 4; i < asdu.length; ++i)
 				if (apdu[2 + i] != asdu[i])
 					throw new KNXRemoteException("read back failed (erroneous property data)");

--- a/src/io/calimero/mgmt/ManagementClientImpl.java
+++ b/src/io/calimero/mgmt/ManagementClientImpl.java
@@ -159,6 +159,9 @@ public class ManagementClientImpl implements ManagementClient
 
 	private static final int DomainAddressSerialNumberWrite = 0b1111101110;
 
+	private static final int PID_LOAD_STATE_CONTROL = 5;
+	private static final int PID_RUN_STATE_CONTROL = 6;
+
 	// serves as both req and res
 	private static final int RESTART = 0x0380;
 
@@ -787,10 +790,14 @@ public class ManagementClientImpl implements ManagementClient
 		if (data.length != apdu.length - 6)
 			throw new KNXInvalidResponseException("data lengths differ, bytes: "
 				+ data.length + " written, " + (apdu.length - 6) + " response");
+
 		// explicitly read back written properties
-		for (int i = 4; i < asdu.length; ++i)
-			if (apdu[2 + i] != asdu[i])
-				throw new KNXRemoteException("read back failed (erroneous property data)");
+		// skip if writing to load/run state control properties
+		if (propertyId != PID_LOAD_STATE_CONTROL && propertyId != PID_RUN_STATE_CONTROL) {
+			for (int i = 4; i < asdu.length; ++i)
+				if (apdu[2 + i] != asdu[i])
+					throw new KNXRemoteException("read back failed (erroneous property data)");
+		}
 	}
 
 	private static final int PropertyExtWrite = 0b0111001110;


### PR DESCRIPTION
Updates the writeProperty() method in ManagementClient to skip read-back validation for property IDs 5 (PID_LOAD_STATE_CONTROL) and 6 (PID_RUN_STATE_CONTROL). These properties return a resulting state code, which may differ from the written value, causing false negatives during validation.

Fixes #150